### PR TITLE
Ensure bc is copied

### DIFF
--- a/es_modular/interaction/custom_gym/mujoco/ant_maze.py
+++ b/es_modular/interaction/custom_gym/mujoco/ant_maze.py
@@ -21,7 +21,7 @@ class AntObstaclesBigEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         reward = - np.sqrt(np.sum(np.square(self.data.qpos[:2] - self.goal)))
         done = False
         ob = self._get_obs()
-        return ob, reward, done, dict(bc=self.data.qpos[:2],
+        return ob, reward, done, dict(bc=np.array(self.data.qpos[:2]),
                                       x_pos=self.data.qpos[0])
 
     def _get_obs(self):


### PR DESCRIPTION
Previously, this BC was not copied, meaning that if you ran the environment for a few episodes, the BCs from one episode would be copied into the next. Adding this `np.array` ensures that the BC is copied.